### PR TITLE
chore: Use kivra-api-errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.iml
 *~
 .emacs*
+.vscode/*

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-playground/validator/v10 v10.10.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kivra/kivra-api-errors v1.0.3-0.20220923122912-450be7804924 // indirect
 	github.com/krakendio/flatmap v1.1.1 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kivra/kivra-api-errors v1.0.3-0.20220923122912-450be7804924 h1:nOY49CYxH3UXMTqudP6nIhWoxfLKfhpjUrhbgHjk6MM=
+github.com/kivra/kivra-api-errors v1.0.3-0.20220923122912-450be7804924/go.mod h1:TgxmYVUthhW91bDG9olLdFgh7f20RJJI3oqdqPr7uGk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/sizelimit_test.go
+++ b/sizelimit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	apierrors "github.com/kivra/kivra-api-errors"
 )
 
 func TestIntNoUnit(t *testing.T) {
@@ -118,6 +119,11 @@ func TestRequestSizeAboveLimit(t *testing.T) {
 
 	if res.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("returned %v %s. should return 413", res.Code, res.Body)
+	}
+
+	errorCode := res.Header().Get(apierrors.ErrorCodeHeader)
+	if errorCode != "41300" {
+		t.Fatalf("returned %s. should return 41300", errorCode)
 	}
 }
 


### PR DESCRIPTION
## About

Generate errors using the kivra-api-errors library and set `X-Error-Code` headers. Good to do now so that it's fixed for good for all middlewares.